### PR TITLE
WIP: Start tests for drop2

### DIFF
--- a/drop2/__main__.py
+++ b/drop2/__main__.py
@@ -1,4 +1,4 @@
-import sys
-from lib2to3.main import main
+from drop2.main import main
 
-sys.exit(main("fixes"))
+
+main()

--- a/drop2/main.py
+++ b/drop2/main.py
@@ -1,0 +1,6 @@
+import sys
+from lib2to3.main import main as lib2to3main
+
+
+def main():
+    sys.exit(lib2to3main("drop2.fixes"))

--- a/tests/test_fix_open.py
+++ b/tests/test_fix_open.py
@@ -1,0 +1,51 @@
+from contextlib import contextmanager
+from pathlib import Path
+import pytest
+from textwrap import dedent
+from tempfile import NamedTemporaryFile
+import sys
+
+from drop2.main import main
+
+
+def test_io_open_import_removed():
+    INPUT = dedent("""
+    import sys
+    from io import open
+
+    print(open(sys.argv[1]).read())
+    """).strip()
+    EXPECTED = dedent("""
+    import sys
+
+    print(open(sys.argv[1]).read())
+    """).strip()
+    with make_file(INPUT) as tmp_file:
+        with patch_args(['-w', str(tmp_file)]):
+            with pytest.raises(SystemExit):
+                main()
+        assert tmp_file.read_text() == EXPECTED
+
+
+@contextmanager
+def make_file(contents=None):
+    """Context manager providing name of a file containing given contents."""
+    with NamedTemporaryFile(mode='wt', encoding='utf-8', delete=False) as f:
+        if contents:
+            f.write(contents)
+    path = Path(f.name)
+    try:
+        yield path
+    finally:
+        path.unlink()
+
+
+@contextmanager
+def patch_args(args=[]):
+    """Context manager providing name of a file containing given contents."""
+    old_args = sys.argv
+    try:
+        sys.argv = [old_args[0], *args]
+        yield
+    finally:
+        sys.argv = old_args


### PR DESCRIPTION
Requirements:

- drop2 installed with pip install -e .
- pytest installed

Refactorings needed:

- should be a tests.utils module with a helper to make testing given
inputs and expected outputs easier
- stdout/stderr should be patched using pytest